### PR TITLE
Fix bug where ldid would hang if the binary was already signed

### DIFF
--- a/minimal/stdlib.h
+++ b/minimal/stdlib.h
@@ -115,7 +115,7 @@ struct Iterator_ {
     for (bool _stop(true); _stop; ) \
         for (const __typeof__(list) &_list = (list); _stop; _stop = false) \
             for (Iterator_<__typeof__(list)>::Result _item = _list.begin(); _item != _list.end(); ++_item) \
-                for (bool _suck(true); _suck; ) \
+                for (bool _suck(true); _suck; _suck = false) \
                     for (const __typeof__(*_item) &item = *_item; _suck; _suck = false)
 
 #endif


### PR DESCRIPTION
The _foreach macro contains a bug in which if "break" is called in the inner loop, the look would restart, possibly causing the loop to recur forever and hanging the program.

Specifically, if using "ldid -S" on a binary that is already signed, the "break" at ldid.cpp:640 would cause that loop to loop infinitely.
